### PR TITLE
bugfix: `exports` key is ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Provide common functionality for customized Laboperator middleware.",
   "main": "src/index.js",
   "exports": {
-    "./config": "./src/config",
-    "./errors": "./src/errors",
-    "./helpers": "./src/helpers",
-    "./laboperator": "./src/laboperator",
-    "./test_helper": "./src/test_helper"
+    "./config": "./src/config/index.js",
+    "./errors": "./src/errors/index.js",
+    "./helpers": "./src/helpers/index.js",
+    "./laboperator": "./src/laboperator/index.js",
+    "./test_helper": "./src/test_helper/index.js"
   },
   "repository": "git@github.com:labforward/laboperator-middleware.git",
   "author": "ignatius.reza@labforward.io",

--- a/src/templates/init/.circleci/config.yml
+++ b/src/templates/init/.circleci/config.yml
@@ -28,7 +28,7 @@ aliases:
   # -------------------
   docker_test_stack: &docker_test_stack
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:14
         environment:
           NODE_ENV: test
 


### PR DESCRIPTION
didn't realized..

current LTS are v12, and `exports` are only supported from v13.. in v14, `index.js` becomes mandatory..

v14 is scheduled to be LTS this october..