### PR TITLE
[CUB-2448] Auto-retry initial token request

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ajv": "^6.12.3",
     "camelcase-keys": "^6.2.2",
     "express": "^4.17.1",
+    "fetch-retry": "^4.0.1",
     "form-data": "^3.0.0",
     "fs-extra": "^9.0.1",
     "http-errors": "^1.8.0",

--- a/src/helpers/authentication.js
+++ b/src/helpers/authentication.js
@@ -60,17 +60,18 @@ module.exports = (application) => {
 
   const authenticateAsUser = (user) => authenticateWith(get(user));
 
-  const fetchToken = async (body) => {
+  const fetchToken = async (body, options) => {
     const { authentication } = config[application];
-    const { options, serializer, ...rest } = authentication.token;
+    const { options: tokenOptions, serializer, ...rest } = authentication.token;
     const response = await fetch({
       ...rest,
       method: 'post',
       body: serializerFor(serializer)({
-        ...options,
+        ...tokenOptions,
         ...body,
       }),
       headers: headersFor(serializer),
+      ...options,
     });
 
     if (!response.ok) {

--- a/src/helpers/fetch.js
+++ b/src/helpers/fetch.js
@@ -1,10 +1,13 @@
+const _ = require('lodash');
 const fetch = require('swagger-client').http;
+const fetchRetry = require('fetch-retry')(fetch);
 const ProxyAgent = require('https-proxy-agent');
 
 module.exports = ({ proxy, ...rest }) => {
-  if (!proxy) return fetch(rest);
+  const fetchOptions = proxy ? { agent: new ProxyAgent(proxy), ...rest } : rest;
+  const retryOptions = _.pick(rest, ['retries', 'retryDelay', 'retryOn']);
 
-  const agent = new ProxyAgent(proxy);
-
-  return fetch({ agent, ...rest });
+  return _.isEmpty(retryOptions)
+    ? fetch(fetchOptions)
+    : fetchRetry(fetchOptions, retryOptions);
 };

--- a/src/laboperator/client/create.js
+++ b/src/laboperator/client/create.js
@@ -8,7 +8,16 @@ const initialize = async () => {
     {},
     {
       retries: 10,
-      retryDelay: (attempt) => Math.pow(2, attempt) * 1000,
+      retryDelay: (attempt) => {
+        const seconds = Math.pow(2, attempt + 1);
+
+        config.logger.debug(
+          `[API][Attempt#${
+            attempt + 1
+          }] Failed to connect to Laboperator API! Retrying in ${seconds} seconds`
+        );
+        return seconds * 1000;
+      },
     }
   );
 

--- a/src/laboperator/client/create.js
+++ b/src/laboperator/client/create.js
@@ -4,7 +4,13 @@ const authentication = require('./authentication');
 const { APIError } = require('../../errors');
 
 const initialize = async () => {
-  const response = await authentication.fetchToken();
+  const response = await authentication.fetchToken(
+    {},
+    {
+      retries: 10,
+      retryDelay: (attempt) => Math.pow(2, attempt) * 1000,
+    }
+  );
 
   authentication.update('default', response);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,6 +1403,11 @@ fetch-mock@^9.10.5:
     querystring "^0.2.0"
     whatwg-url "^6.5.0"
 
+fetch-retry@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-4.0.1.tgz#ca746666399aaf0547aa3851ccb543cfb112b8da"
+  integrity sha512-EhIeVBkq9T2z1ANDr2kmLujoHOTdLvR9t/nzLSdX4PMIFinLyyZFYX9T6Fb3LrbiHQEhujq1O7ElsqjuqYIsEA==
+
 file-entry-cache@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"


### PR DESCRIPTION
Since the laboperator-server might still be booting up..

If the request is not retried, the middleware will be left in a broken state and is unable to serve requests..