### PR TITLE
[CUB-2691] Failed refreshing laboperator access token

### DIFF
--- a/src/helpers/authentication.js
+++ b/src/helpers/authentication.js
@@ -147,10 +147,18 @@ module.exports = (application, { persisted = false } = {}) => {
     return tokens[user];
   };
 
+  const store = (user, token) => {
+    tokens[user] = Promise.resolve(token);
+    tokens.save();
+  };
+
   const get = async (user = 'default') => {
     let token = await tokens[user];
 
-    if (token && isExpired(token)) token = await refreshToken(user);
+    if (token && isExpired(token)) {
+      token = await refreshToken(user);
+      store(user, token);
+    }
 
     return token && token.accessToken;
   };
@@ -174,10 +182,7 @@ module.exports = (application, { persisted = false } = {}) => {
     authenticateAsUser: async (user) => authenticateWith(await get(user)),
     fetchToken,
     get,
-    store: (user, newToken) => {
-      tokens[user] = Promise.resolve(newToken);
-      tokens.save();
-    },
+    store,
   };
 
   return authentications[application];

--- a/src/test_helper/fixtures/documentation.json
+++ b/src/test_helper/fixtures/documentation.json
@@ -46688,12 +46688,28 @@
         "summary": "Get Workflow Fields",
         "parameters": [
           {
+            "name": "filter",
+            "description": "Resources and/or attributes to filter by.",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/WorkflowFieldsFilter"
+            }
+          },
+          {
             "name": "fields",
             "in": "query",
             "schema": {
               "type": "object"
             },
             "description": "List of WorkflowField attributes to be included in the response."
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Include archived workflow fields."
           },
           {
             "name": "include",
@@ -46721,14 +46737,6 @@
               "type": "object"
             },
             "description": "Sorting"
-          },
-          {
-            "name": "filter",
-            "description": "Resources and/or attributes to filter by.",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/WorkflowFieldsFilter"
-            }
           }
         ],
         "security": [


### PR DESCRIPTION
when user authorized the middleware to authenticate as the user, the middleware store a pair of access and refresh token..

when the access token expired, the middleware will use the refresh token to get a new access token.. once the new access token is used in any way to authenticate user against laboperator, the refresh token is automatically revoked..

with each access token, a corresponding updated refresh token is also, generated, so instead of reusing the original refresh token multiple time every time access token expired, we have to store both access and refresh token, and use only the latest token both when authenticating as user and when refreshing the access token..